### PR TITLE
remote vector_prompts feature fixed

### DIFF
--- a/pixray.py
+++ b/pixray.py
@@ -599,6 +599,7 @@ def do_init(args):
         else:
             vect_table = json.load(infile_handle)
         for clip_model in args.clip_models:
+            if clip_model not in vect_table: continue
             pMs = pmsTable[clip_model]
             v = np.array(vect_table[clip_model])
             embed = torch.FloatTensor(v).to(device).float()

--- a/pixray.py
+++ b/pixray.py
@@ -585,15 +585,19 @@ def do_init(args):
         weight = 0.1 * weight
         if 'http' in f1:
             # note: this is currently untested...
-            infile = urlopen(f1)
+            infile = None
+            infile_handle = urlopen(f1)
         elif 'json' in f1:
             infile = f1
         else:
             infile = f"vectors/{f1}.json"
             if not os.path.exists(infile):
                 infile = f"pixray/vectors/{f1}.json"
-        with open(infile) as f_in:
-            vect_table = json.load(f_in)
+        if infile:
+            with open(infile) as f_in:
+                vect_table = json.load(f_in)
+        else:
+            vect_table = json.load(infile_handle)
         for clip_model in args.clip_models:
             pMs = pmsTable[clip_model]
             v = np.array(vect_table[clip_model])

--- a/pixray.py
+++ b/pixray.py
@@ -600,7 +600,6 @@ def do_init(args):
             vect_table = json.load(infile_handle)
         for clip_model in args.clip_models:
             if clip_model not in vect_table: continue
-            print(clip_model, pmsTable.keys(), vect_table.keys())
             pMs = pmsTable[clip_model]
             v = np.array(vect_table[clip_model])
             embed = torch.FloatTensor(v).to(device).float()

--- a/pixray.py
+++ b/pixray.py
@@ -600,6 +600,7 @@ def do_init(args):
             vect_table = json.load(infile_handle)
         for clip_model in args.clip_models:
             if clip_model not in vect_table: continue
+            print(clip_model, pmsTable.keys(), vect_table.keys())
             pMs = pmsTable[clip_model]
             v = np.array(vect_table[clip_model])
             embed = torch.FloatTensor(v).to(device).float()


### PR DESCRIPTION
In the current master branch it doesn't work:

```
--> 595         with open(infile) as f_in:
TypeError: expected str, bytes or os.PathLike object, not HTTPResponse
```