### PR TITLE
bugfix: issue#18 cell count 0, num_resolutions

### DIFF
--- a/clipdrawer.py
+++ b/clipdrawer.py
@@ -123,8 +123,7 @@ class ClipDrawer(DrawingInterface):
         return None
 
     def get_num_resolutions(self):
-        # TODO
-        return 5
+        return None
 
     def synth(self, cur_iteration):
         render = pydiffvg.RenderFunction.apply

--- a/linedrawer.py
+++ b/linedrawer.py
@@ -151,8 +151,7 @@ class LineDrawer(DrawingInterface):
         return None
 
     def get_num_resolutions(self):
-        # TODO
-        return 5
+        return None
 
     def synth(self, cur_iteration):
         render = pydiffvg.RenderFunction.apply

--- a/pixeldrawer.py
+++ b/pixeldrawer.py
@@ -134,6 +134,17 @@ class PixelDrawer(DrawingInterface):
             self.num_cols = int(self.num_cols / settings.pixel_scale)
             self.num_rows = int(self.num_rows / settings.pixel_scale)
 
+
+        shrink = False
+        if self.num_cols>self.canvas_width:
+            shrink = True
+            self.num_cols = self.canvas_width
+        if self.num_rows>self.canvas_height:
+            shrink = True
+            self.num_rows = self.canvas_height
+        if shrink:
+            print('pixel grid size should not be larger than output pixel size: reducing pixel grid')
+
         print(f"Running pixeldrawer with {self.num_cols}x{self.num_rows} grid")
 
         if settings.pixel_edge_check:
@@ -218,7 +229,7 @@ class PixelDrawer(DrawingInterface):
                             for t_y in tensor_subsamples_y:
                                 cur_subsample_y = tensor_cur_y + t_y
                                 if(cur_subsample_x < tensor_shape[3] and cur_subsample_y < tensor_shape[2]):
-                                    rgb_count += 1;
+                                    rgb_count += 1
                                     rgb_sum[0] += scaled_init_tensor[0][int(cur_subsample_y)][int(cur_subsample_x)]
                                     rgb_sum[1] += scaled_init_tensor[1][int(cur_subsample_y)][int(cur_subsample_x)]
                                     rgb_sum[2] += scaled_init_tensor[2][int(cur_subsample_y)][int(cur_subsample_x)]
@@ -286,8 +297,7 @@ class PixelDrawer(DrawingInterface):
         return None
 
     def get_num_resolutions(self):
-        # TODO
-        return 5
+        return None
 
     def synth(self, cur_iteration):
         if cur_iteration < 0:

--- a/pixray.py
+++ b/pixray.py
@@ -478,10 +478,13 @@ def do_init(args):
     # print("-----------> NUMR ", num_resolutions)
 
     jit = True if float(torch.__version__[:3]) < 1.8 else False
-    f = 2**(num_resolutions - 1)
-
-    toksX, toksY = args.size[0] // f, args.size[1] // f
-    sideX, sideY = toksX * f, toksY * f
+    
+    if num_resolutions!=None:
+        f = 2**(num_resolutions - 1)
+        toksX, toksY = args.size[0] // f, args.size[1] // f
+        sideX, sideY = toksX * f, toksY * f
+    else:
+        sideX, sideY = args.size[0], args.size[1]
 
     # save sideX, sideY in globals (need if using overlay)
     gside_X = sideX


### PR DESCRIPTION
Solution for the "init_image: init cell count is 0, this shouldn't happen. but it did?" bug when using this code

`pixray.add_settings(size=[320,180], pixel_size=[320,180])`

Added an if statement for get_num_resolutions(), when not VQGAN it would not reduce size of the output.
Added a warning for pixeldrawer, if input size is smaller than pixel_size, pixel_size will auto resize down to size.