### PR TITLE
fix: modify existing tensors when updating pixeldrawer with image

### DIFF
--- a/pixray.py
+++ b/pixray.py
@@ -1142,7 +1142,7 @@ def re_average_z(args):
     cur_z_image = cur_z_image.convert('RGB')
     if overlay_image_rgba:
         # print("applying overlay image")
-        cur_z_image.paste(overlay_image_rgba, (0, 0), overlay_image_rgba)
+        cur_z_image.paste(overlay_image_rgba, (0, 0), mask=overlay_image_rgba)
         # cur_z_image.save("overlaid.png")
     cur_z_image = cur_z_image.resize((gside_X, gside_Y), Image.LANCZOS)
     drawer.reapply_from_tensor(TF.to_tensor(cur_z_image).to(device).unsqueeze(0) * 2 - 1)


### PR DESCRIPTION
This works okay but it seems like it's slower to create the image if you do something like `overlay_every=1`. I might be misusing the old optimizer statistics like this but if I understand the code correctly then it should be fine.

The slower optimization might instead be because I am changing the image back all the time and we don't have separate learning rate groups for different parts of the image (I am overlaying only a part of the image) so this confuses the optimizer statistics.

Overlays are at least working decently now. I suspect this should have affected animations as well since `init_anim_z` used the same function.