### PR TITLE
Gracefully handle prompts with colons but no weights

### DIFF
--- a/pixray.py
+++ b/pixray.py
@@ -248,10 +248,19 @@ class Prompt(nn.Module):
 
 
 def parse_prompt(prompt):
+    """Prompts can either just be text, be a text:weight pair, or a text:weight:stop triple"""
     vals = prompt.rsplit(':', 2)
-    vals = vals + ['', '1', '-inf'][len(vals):]
+
+    textPrompt = vals[0]
+    try:
+        weight = float(vals[1]) if len(vals) > 1 else 1
+        stop = float(vals[2]) if len(vals) > 2 else float('-inf')
+    except ValueError:
+        print('Warning, failed to parse prompt weights, assuming prompt does not contain weights.')
+        return prompt, 1, float('-inf')
+
     # print(f"parsed vals is {vals}")
-    return vals[0], float(vals[1]), float(vals[2])
+    return textPrompt, weight, stop
 
 from typing import cast, Dict, List, Optional, Tuple, Union
 


### PR DESCRIPTION
When a prompt contains a colon (i.e. "Star Wars: Return of the Sith"), it will currently crash generation. This is a small change to prompt parsing to gracefully handle this case. Before:

```
>>> parse_prompt("hello world:2")
('hello world', 2.0, -inf)
>>> parse_prompt("hello world:2:15")
('hello world', 2.0, 15.0)
>>> parse_prompt("hello world: my name is Mitchell.")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Volumes/Repos/pixray/pixray.py", line 254, in parse_prompt
    return vals[0], float(vals[1]), float(vals[2])
ValueError: could not convert string to float: ' my name is Mitchell.'
```

After:
```
>> parse_prompt("hello world")
('hello world', 1, -inf)
>>> parse_prompt("hello world:2")
('hello world', 2.0, -inf)
>>> parse_prompt("hello world:2:15")
('hello world', 2.0, 15.0)
>>> parse_prompt("hello world: my name is Mitchell")
Warning, failed to parse prompt weights, assuming prompt does not contain weights.
('hello world: my name is Mitchell', 1, -inf)
```